### PR TITLE
Raspberry pi hackery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ Full documentation is available in the
 
 The content of this Docker repository is licensed under the AGPLv3+
 license.
+
+Note: This branch contains several small changes so that docker instances can be created for the Raspberry Pi 4 (64 bit OS).
+
+Other changes include changing the base image from ubuntu:14.04 to ubuntu:22.04 and the version of Python from 3.7 to 3.10.12. Also - the calls to mercurial (e.g., 'hg') have all been replaced with wget calls to the zip files for the source (such as 'https://www.orthanc-server.com/downloads/get.php?path=/plugin-dicom-web/OrthancDicomWeb-1.15.tar.gz') because the mercurial URLs returned 404 messages.
+
+There are some other minor changes made in the installed packages. These were made simply to get the system to compile. Also - changes were only made in the base, orthanc, orthanc-plugins-big, and orthanc-python subdirectories. Little testing has been done except that simple python programs run successfully.
+

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:22.04
 
 MAINTAINER Sebastien Jodogne <s.jodogne@gmail.com>
 LABEL Description="Base environment to build Orthanc" Vendor="The Orthanc project"

--- a/base/build.sh
+++ b/base/build.sh
@@ -1,0 +1,1 @@
+docker build -f Dockerfile --tag seandoyle/orthanc-base .

--- a/orthanc-plugins-big/Dockerfile
+++ b/orthanc-plugins-big/Dockerfile
@@ -1,10 +1,10 @@
-FROM jodogne/base
+FROM seandoyle/orthanc-base
 
 MAINTAINER Sebastien Jodogne <s.jodogne@gmail.com>
 LABEL Description="Orthanc, free DICOM server" Vendor="The Orthanc project"
 
 RUN apt-get clean && apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libgdcm2-dev libjpeg-dev postgresql-server-dev-all libtiff-dev libopenjpeg-dev libopenslide-dev && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libgdcm-dev libjpeg-dev postgresql-server-dev-all libtiff-dev libopenslide-dev libcivetweb-dev protobuf-compiler locales tzdata && rm -rf /var/lib/apt/lists/*
 
 ADD ./build-orthanc.sh /root/build-orthanc.sh
 RUN bash /root/build-orthanc.sh "default"
@@ -18,8 +18,8 @@ RUN bash /root/build-postgresql.sh "default"
 ADD ./build-dicomweb.sh /root/build-dicomweb.sh
 RUN bash /root/build-dicomweb.sh "default"
 
-ADD ./build-wsi.sh /root/build-wsi.sh
-RUN bash /root/build-wsi.sh "default"
+#ADD ./build-wsi.sh /root/build-wsi.sh
+#RUN bash /root/build-wsi.sh "default"
 
 VOLUME [ "/var/lib/orthanc/db" ]
 EXPOSE 4242

--- a/orthanc-plugins-big/build-dicomweb.sh
+++ b/orthanc-plugins-big/build-dicomweb.sh
@@ -27,9 +27,12 @@ echo "Will use $COUNT_CORES parallel jobs to build Orthanc"
 
 # Clone the repository and switch to the requested branch
 cd /root/
-hg clone https://bitbucket.org/sjodogne/orthanc-dicomweb/
-cd orthanc-dicomweb
-hg up -c "$1"
+wget --no-check-certificate -O OrthancDicomWeb-1.15.tar.gz https://www.orthanc-server.com/downloads/get.php?path=/plugin-dicom-web/OrthancDicomWeb-1.15.tar.gz
+tar -xvf OrthancDicomWeb-1.15.tar.gz
+cd OrthancDicomWeb-1.15
+#hg clone https://bitbucket.org/sjodogne/orthanc-dicomweb/
+#cd orthanc-dicomweb
+#hg up -c "$1"
 
 # Build the plugin
 mkdir Build

--- a/orthanc-plugins-big/build-orthanc.sh
+++ b/orthanc-plugins-big/build-orthanc.sh
@@ -32,10 +32,14 @@ mkdir -p /usr/share/orthanc/plugins
 
 # Clone the Orthanc repository and switch to the requested branch
 cd /root/
-hg clone https://bitbucket.org/sjodogne/orthanc/ orthanc
-cd orthanc
-echo "Switching Orthanc to branch: $1"
-hg up -c "$1"
+wget --no-check-certificate -O  Orthanc-1.12.1.tar.gz  https://www.orthanc-server.com/downloads/get.php?path=/orthanc/Orthanc-1.12.1.tar.gz
+tar -xvf Orthanc-1.12.1.tar.gz
+ls -l .
+# hg clone https://bitbucket.org/sjodogne/orthanc/ orthanc
+cd  Orthanc-1.12.1/OrthancServer
+pwd
+echo "Downloaded source"
+#hg up -c "$1"
 
 # Build the Orthanc core
 mkdir Build
@@ -62,7 +66,7 @@ make install
 
 # Remove the build directory to recover space
 cd /root/
-rm -rf /root/orthanc
+rm -rf /root/Orthanc-1.12.1
 
 # Auto-generate, then patch the configuration file
 CONFIG=/etc/orthanc/orthanc.json

--- a/orthanc-plugins-big/build-python.sh
+++ b/orthanc-plugins-big/build-python.sh
@@ -27,25 +27,32 @@ echo "Will use $COUNT_CORES parallel jobs to build Orthanc"
 
 # Clone the repository and switch to the requested branch
 cd /root/
-wget --no-check-certificate -O  OrthancPostgresql-5.1.tar.gz https://www.orthanc-server.com/downloads/get.php?path=/plugin-postgresql/OrthancPostgreSQL-5.1.tar.gz
-tar -xvf OrthancPostgresql-5.1.tar.gz
-cd OrthancPostgresql-5.1/PostgreSQL
-#hg clone https://bitbucket.org/sjodogne/orthanc-postgresql/
-#cd orthanc-postgresql
-#hg up -c "$1"
+hg clone https://bitbucket.org/sjodogne/orthanc-wsi/
+cd orthanc-wsi
+hg up -c "$1"
 
-# Build the plugin
+# Build the viewer plugin
+cd /root/orthanc-wsi/ViewerPlugin
 mkdir Build
 cd Build
 cmake -DALLOW_DOWNLOADS:BOOL=ON \
     -DCMAKE_BUILD_TYPE:STRING=Release \
-    -DUSE_GOOGLE_TEST_DEBIAN_PACKAGE:BOOL=ON \
     -DUSE_SYSTEM_JSONCPP:BOOL=OFF \
     ..
 make -j$COUNT_CORES
-cp -L libOrthancPostgreSQLIndex.so /usr/share/orthanc/plugins/
-cp -L libOrthancPostgreSQLStorage.so /usr/share/orthanc/plugins/
+cp -L libOrthancWSI.so /usr/share/orthanc/plugins/
+
+# Build the DICOM-ization applications
+cd /root/orthanc-wsi/Applications
+mkdir Build
+cd Build
+cmake -DALLOW_DOWNLOADS:BOOL=ON \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DUSE_SYSTEM_JSONCPP:BOOL=OFF \
+    ..
+make -j$COUNT_CORES
+make install
 
 # Remove the build directory to recover space
 cd /root/
-rm -rf /root/OrthancPostgresql-5.1.tar.gz
+rm -rf /root/orthanc-wsi

--- a/orthanc-plugins-big/build-webviewer.sh
+++ b/orthanc-plugins-big/build-webviewer.sh
@@ -27,9 +27,12 @@ echo "Will use $COUNT_CORES parallel jobs to build Orthanc"
 
 # Clone the repository and switch to the requested branch
 cd /root/
-hg clone https://bitbucket.org/sjodogne/orthanc-webviewer/
-cd orthanc-webviewer
-hg up -c "$1"
+wget --no-check-certificate -O ./OrthancWebViewer-2.8.tar.gz  https://www.orthanc-server.com/downloads/get.php?path=/plugin-webviewer/OrthancWebViewer-2.8.tar.gz
+tar -xvf ./OrthancWebViewer-2.8.tar.gz
+cd OrthancWebViewer-2.8
+# hg clone https://bitbucket.org/sjodogne/orthanc-webviewer/
+#cd orthanc-webviewer
+#hg up -c "$1"
 
 # Build the plugin
 mkdir Build

--- a/orthanc-plugins-big/build.sh
+++ b/orthanc-plugins-big/build.sh
@@ -1,0 +1,1 @@
+docker build -f Dockerfile --tag seandoyle/orthanc-big .

--- a/orthanc-python/CMakeLists.txt
+++ b/orthanc-python/CMakeLists.txt
@@ -1,0 +1,212 @@
+cmake_minimum_required(VERSION 2.8)
+project(OrthancPython)
+
+set(PLUGIN_VERSION "4.1")
+
+if (PLUGIN_VERSION STREQUAL "mainline")
+  set(ORTHANC_FRAMEWORK_DEFAULT_VERSION "mainline")
+  set(ORTHANC_FRAMEWORK_DEFAULT_SOURCE "hg")
+else()
+  set(ORTHANC_FRAMEWORK_DEFAULT_VERSION "1.12.1")
+  set(ORTHANC_FRAMEWORK_DEFAULT_SOURCE "web")
+endif()
+
+
+if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  # The Python version cannot be controlled on OS X (yet)
+  set(PYTHON_VERSION "3.10" CACHE STRING "Version of Python to be used")
+endif()
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+  # Windows-specific options
+  set(PYTHON_WINDOWS_ROOT "" CACHE STRING "")
+  set(PYTHON_LIBRARY_NAME "" CACHE STRING "")
+  set(PYTHON_WINDOWS_USE_RELEASE_LIBS ON CACHE BOOL "Use the release Python libraries when building with Microsoft Visual Studio, even when compiling in _DEBUG mode (set it to OFF if you require linking to a Python debug build)")
+endif()
+
+
+
+# Parameters of the build
+set(STATIC_BUILD OFF CACHE BOOL "Static build of the third-party libraries (necessary for Windows)")
+set(ALLOW_DOWNLOADS OFF CACHE BOOL "Allow CMake to download packages")
+set(ORTHANC_FRAMEWORK_SOURCE "${ORTHANC_FRAMEWORK_DEFAULT_SOURCE}" CACHE STRING "Source of the Orthanc framework (can be \"system\", \"hg\", \"archive\", \"web\" or \"path\")")
+set(ORTHANC_FRAMEWORK_VERSION "${ORTHANC_FRAMEWORK_DEFAULT_VERSION}" CACHE STRING "Version of the Orthanc framework")
+set(ORTHANC_FRAMEWORK_ARCHIVE "" CACHE STRING "Path to the Orthanc archive, if ORTHANC_FRAMEWORK_SOURCE is \"archive\"")
+set(ORTHANC_FRAMEWORK_ROOT "" CACHE STRING "Path to the Orthanc source directory, if ORTHANC_FRAMEWORK_SOURCE is \"path\"")
+set(USE_FRAMEWORK_ORTHANC_SDK OFF CACHE BOOL "Whether to use the SDK from the Orthanc sources (for developers only, to support new features of the SDK that are still pending in the mainline)")
+
+# Advanced parameters to fine-tune linking against system libraries
+set(ORTHANC_FRAMEWORK_STATIC OFF CACHE BOOL "If linking against the Orthanc framework system library, indicates whether this library was statically linked")
+mark_as_advanced(ORTHANC_FRAMEWORK_STATIC)
+
+
+# Download and setup the Orthanc framework
+include(${CMAKE_SOURCE_DIR}/Resources/Orthanc/CMake/DownloadOrthancFramework.cmake)
+
+if (ORTHANC_FRAMEWORK_SOURCE STREQUAL "system")
+  include(FindBoost)
+  find_package(Boost COMPONENTS filesystem regex thread)
+
+  if (NOT Boost_FOUND)
+    message(FATAL_ERROR "Unable to locate Boost on this system")
+  endif()
+
+  link_libraries(${Boost_LIBRARIES} jsoncpp)
+
+else()
+  include(${ORTHANC_FRAMEWORK_ROOT}/../Resources/CMake/OrthancFrameworkParameters.cmake)
+  
+  #set(ENABLE_MODULE_IMAGES OFF CACHE INTERNAL "")
+  #set(ENABLE_MODULE_JOBS OFF CACHE INTERNAL "")
+  #set(ENABLE_MODULE_DICOM OFF CACHE INTERNAL "")
+  
+  include(${ORTHANC_FRAMEWORK_ROOT}/../Resources/CMake/OrthancFrameworkConfiguration.cmake)
+  include_directories(${ORTHANC_FRAMEWORK_ROOT})
+endif()
+
+
+include(${CMAKE_SOURCE_DIR}/Resources/Orthanc/Plugins/OrthancPluginsExports.cmake)
+
+
+include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
+include(CheckIncludeFiles)
+include(CheckLibraryExists)
+include(FindPythonInterp)
+
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  find_package(PythonLibs)
+  if (NOT PYTHONLIBS_FOUND)
+    message(FATAL_ERROR "Cannot find the Python libraries")
+  endif()
+
+  message("Python library - Found version: ${PYTHONLIBS_VERSION_STRING}")
+  message("Python library - Path to include directory: ${PYTHON_INCLUDE_DIRS}")
+  message("Python library - Shared library: ${PYTHON_LIBRARIES}")
+
+else()
+  string(REGEX REPLACE "^([0-9]*)\\.([0-9]*)$" "\\1" PYTHON_VERSION_MAJOR ${PYTHON_VERSION})
+  string(REGEX REPLACE "^([0-9]*)\\.([0-9]*)$" "\\2" PYTHON_VERSION_MINOR ${PYTHON_VERSION})
+
+  if (NOT PYTHON_VERSION STREQUAL
+      "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+    message(FATAL_ERROR "Error in the (x.y) format of the Python version: ${PYTHON_VERSION}")
+  endif()
+
+  if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    if ("${PYTHON_LIBRARY_NAME}" STREQUAL "")
+      if (MSVC)
+        set(Prefix "")
+        set(Suffix ".lib")
+        if(PYTHON_WINDOWS_USE_RELEASE_LIBS)
+          add_definitions(-DORTHANC_PYTHON_WINDOWS_USE_RELEASE_LIBS=1)
+        endif()
+      else()
+        list(GET CMAKE_FIND_LIBRARY_PREFIXES 0 Prefix)
+        set(Suffix ".a")
+      endif()
+      
+      set(PYTHON_LIBRARY_NAME ${Prefix}python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}${Suffix})
+    endif()
+    
+    if (CMAKE_COMPILER_IS_GNUCXX AND
+        "${CMAKE_SIZEOF_VOID_P}" STREQUAL "8" AND
+        "${PYTHON_VERSION}" STREQUAL "2.7")
+      # Fix for MinGW 64bit: https://stackoverflow.com/a/19867426/881731
+      add_definitions(-DMS_WIN64)
+    endif()
+    
+    set(PYTHON_INCLUDE_DIRS ${PYTHON_WINDOWS_ROOT}/include)
+    set(PYTHON_LIBRARIES ${PYTHON_WINDOWS_ROOT}/libs/${PYTHON_LIBRARY_NAME})
+    
+    execute_process(
+      COMMAND 
+      ${PYTHON_EXECUTABLE} ${ORTHANC_FRAMEWORK_ROOT}/../Resources/WindowsResources.py
+      ${PLUGIN_VERSION} "Python plugin" OrthancPython.dll
+      "Plugin to create Orthanc plugins using Python"
+      ERROR_VARIABLE Failure
+      OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/Version.rc
+      )
+
+    if (Failure)
+      message(FATAL_ERROR "Error while computing the version information: ${Failure}")
+    endif()
+
+    set(WINDOWS_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/Version.rc)
+
+  else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(PYTHON_1 python-${PYTHON_VERSION}-embed)
+
+    if (PYTHON_1_FOUND)
+      set(PYTHON_INCLUDE_DIRS ${PYTHON_1_INCLUDE_DIRS})
+      set(PYTHON_LIBRARIES ${PYTHON_1_LIBRARIES})
+    else()
+      pkg_check_modules(PYTHON_2 REQUIRED python-${PYTHON_VERSION})
+      set(PYTHON_INCLUDE_DIRS ${PYTHON_2_INCLUDE_DIRS})
+      set(PYTHON_LIBRARIES ${PYTHON_2_LIBRARIES})
+    endif()
+  endif()
+endif()
+
+
+if (USE_FRAMEWORK_ORTHANC_SDK)
+  include_directories(
+    ${ORTHANC_FRAMEWORK_ROOT}/../../OrthancServer/Plugins/Include
+    )
+else()
+  include_directories(
+    ${CMAKE_SOURCE_DIR}/Resources/Orthanc/Sdk-1.10.0
+    )
+endif()
+
+add_definitions(
+  -DHAS_ORTHANC_EXCEPTION=0
+  )
+
+include_directories(
+  ${PYTHON_INCLUDE_DIRS}
+  )
+
+add_library(OrthancPython SHARED
+  Sources/Autogenerated/sdk.cpp
+  Sources/DicomScpCallbacks.cpp
+  Sources/ICallbackRegistration.cpp
+  Sources/IncomingHttpRequestFilter.cpp
+  Sources/IncomingInstanceFilter.cpp
+  Sources/OnChangeCallback.cpp
+  Sources/OnStoredInstanceCallback.cpp
+  Sources/Plugin.cpp
+  Sources/PythonBytes.cpp
+  Sources/PythonFunction.cpp
+  Sources/PythonLock.cpp
+  Sources/PythonModule.cpp
+  Sources/PythonObject.cpp
+  Sources/PythonString.cpp
+  Sources/ReceivedInstanceCallback.cpp
+  Sources/RestCallbacks.cpp
+  Sources/StorageArea.cpp
+  Sources/StorageCommitmentScpCallback.cpp
+
+  # Third-party sources
+  ${CMAKE_SOURCE_DIR}/Resources/Orthanc/Plugins/OrthancPluginCppWrapper.cpp
+  ${BOOST_SOURCES}
+  ${JSONCPP_SOURCES}
+  ${WINDOWS_RESOURCES}
+  )
+
+target_link_libraries(OrthancPython ${PYTHON_LIBRARIES})
+
+add_definitions(-DPLUGIN_VERSION="${PLUGIN_VERSION}")
+
+set_target_properties(OrthancPython PROPERTIES 
+  VERSION ${PLUGIN_VERSION} 
+  SOVERSION ${PLUGIN_VERSION}
+  )
+
+install(
+  TARGETS OrthancPython
+  RUNTIME DESTINATION lib    # Destination for Windows
+  LIBRARY DESTINATION share/orthanc/plugins    # Destination for Linux
+  )

--- a/orthanc-python/Dockerfile
+++ b/orthanc-python/Dockerfile
@@ -1,15 +1,17 @@
-FROM jodogne/orthanc-plugins
+FROM seandoyle/orthanc-big
 
 MAINTAINER Sebastien Jodogne <s.jodogne@gmail.com>
 LABEL Description="Orthanc, free DICOM server, with plugins and Python" Vendor="The Orthanc project"
 
 RUN apt-get -y clean && apt-get -y update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python3.7 libpython3.7 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# 3.10.12 already installed.
+#RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python3.7 libpython3.7 && \
+#    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+ADD ./CMakeLists.txt  ./CMakeLists.txt  
 ADD ./download-python.sh ./download-python.sh
 RUN bash ./download-python.sh
-
+RUN ls -l /usr/local/share/orthanc/plugins/
 RUN rm ./download-python.sh
 
 VOLUME [ "/var/lib/orthanc/db" ]

--- a/orthanc-python/build.sh
+++ b/orthanc-python/build.sh
@@ -1,0 +1,1 @@
+docker build -f Dockerfile --tag seandoyle/orthanc-python .

--- a/orthanc-python/download-python.sh
+++ b/orthanc-python/download-python.sh
@@ -1,11 +1,30 @@
 #!/bin/bash
 
 set -e
+ls -l
 cd
-
+pwd
+ls -l
 URL=https://lsb.orthanc-server.com/
 VERSION=mainline
 
-wget ${URL}/plugin-python/debian-buster-python-3.7/${VERSION}/libOrthancPython.so
+wget --no-check-certificate -O OrthancPython-4.1.tar.gz https://www.orthanc-server.com/downloads/get.php?path=/plugin-python/OrthancPython-4.1.tar.gz
+tar -xvf  OrthancPython-4.1.tar.gz
+cp /CMakeLists.txt OrthancPython-4.1/CMakeLists.txt
+cd OrthancPython-4.1
+mkdir Build
+cd Build
+cmake -DALLOW_DOWNLOADS:BOOL=ON \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DUSE_GOOGLE_TEST_DEBIAN_PACKAGE:BOOL=ON \
+    -DUSE_SYSTEM_JSONCPP:BOOL=OFF \
+    ..
+make -j$COUNT_CORES
 
-mv ./libOrthancPython.so  /usr/local/share/orthanc/plugins/
+#wget ${URL}/plugin-python/debian-buster-python-3.7/${VERSION}/libOrthancPython.so
+chmod +x libOrthancPython.so
+ls -l *
+cp -L libOrthancPython.so /usr/share/orthanc/plugins/
+
+#cp -L libOrthancPython.so  /usr/local/share/orthanc/plugins/
+ls -l /usr/local/share/orthanc/plugins/

--- a/orthanc-python/download-python.sh
+++ b/orthanc-python/download-python.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 set -e
-ls -l
 cd
-pwd
-ls -l
 URL=https://lsb.orthanc-server.com/
 VERSION=mainline
 
@@ -21,10 +18,8 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     ..
 make -j$COUNT_CORES
 
-#wget ${URL}/plugin-python/debian-buster-python-3.7/${VERSION}/libOrthancPython.so
 chmod +x libOrthancPython.so
 ls -l *
 cp -L libOrthancPython.so /usr/share/orthanc/plugins/
 
-#cp -L libOrthancPython.so  /usr/local/share/orthanc/plugins/
 ls -l /usr/local/share/orthanc/plugins/

--- a/orthanc/build.sh
+++ b/orthanc/build.sh
@@ -1,0 +1,1 @@
+docker build -f Dockerfile --tag raspi/orthanc .


### PR DESCRIPTION
This is a slightly hacky update so that I can run the python plugin in Orthanc on a Raspberry Pi 4 running a 64 bit OS. There are some additional build.sh files that I've included for building the base, orthanc, orthanc-plugins-big, and orthanc-python dockers. 

I don't think that these changes are in a form to be merged in. The build routines should be more cross-platform and the changes to the libraries installed were not done with much research. I'm open to suggestions for making this a more robust PR.