### PR TITLE
docs(readme): update Docker image descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Summary of docker images hosted by this repository:
 | Docker Image Name | Description |
 | --- | --- |
 | `jodogne/orthanc` | Docker image for the Orthanc core. This image is always kept in sync with the latest releases of the Orthanc project, with a basic configuration system that is inherited from the Debian packages. This image is most useful to software developers and researchers. |
-| `jodogne/orthanc-plugins` | Docker image for the Orthanc core, together with its Web viewer, its PostgreSQL support, its DICOMweb implementation, and its whole-slide imaging viewer. |
+| `jodogne/orthanc-plugins` | Docker image for the Orthanc core, together with its most important plugins (notably its Orthanc Web viewer, its PostgreSQL support, its DICOMweb implementation, and its whole-slide imaging viewer). |
 | `jodogne/orthanc-python` | A heavier version of the `orthanc-plugins` image, as it embeds the Python 3.7 interpreter. This image is useful if you have an interest in the Python plugin. |
+
+Full documentation is available in the
+[Orthanc Book](https://orthanc.uclouvain.be/book/users/docker.html).
 
 The content of this Docker repository is licensed under the AGPLv3+
 license.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Orthanc for Docker
 
-[Docker Hub](https://www.docker.com/) repository to build
+[Docker Hub](https://hub.docker.com/u/jodogne) repository to build
 [Orthanc](http://www.orthanc-server.com/) and its official
 plugins. Orthanc is a lightweight, RESTful Vendor Neutral Archive for
 medical imaging.
 
-Full documentation is available in the
-[Orthanc Book](https://orthanc.uclouvain.be/book/users/docker.html).
+Summary of docker images hosted by this repository:
+
+| Docker Image Name | Description |
+| --- | --- |
+| `jodogne/orthanc` | Docker image for the Orthanc core. This image is always kept in sync with the latest releases of the Orthanc project, with a basic configuration system that is inherited from the Debian packages. This image is most useful to software developers and researchers. |
+| `jodogne/orthanc-plugins` | Docker image for the Orthanc core, together with its Web viewer, its PostgreSQL support, its DICOMweb implementation, and its whole-slide imaging viewer. |
+| `jodogne/orthanc-python` | A heavier version of the `orthanc-plugins` image, as it embeds the Python 3.7 interpreter. This image is useful if you have an interest in the Python plugin. |
 
 The content of this Docker repository is licensed under the AGPLv3+
 license.


### PR DESCRIPTION
Hello Sébastien (@jodogne),

I am proposing an update to the Docker image descriptions in the README file of the Orthanc Docker image repository. The changes include more detailed descriptions for the `jodogne/orthanc`, `jodogne/orthanc-plugins`, and `jodogne/orthanc-python` Docker images.

I believe these changes will provide clearer information for users who are looking to use these Docker images.

I am making this PR directly because I was unable to contact the maintainers through the issues. I hope this change is helpful and I look forward to your feedback.

Best,
Bhargava