### PR TITLE
Upgrade to python 3.13

### DIFF
--- a/orthanc-python/download-python.sh
+++ b/orthanc-python/download-python.sh
@@ -6,6 +6,6 @@ cd
 URL=https://orthanc.uclouvain.be/downloads/linux-standard-base
 VERSION=mainline
 
-wget ${URL}/orthanc-python/debian-bookworm-python-3.11/${VERSION}/libOrthancPython.so
+wget ${URL}/orthanc-python/debian-trixie-python-3.13/${VERSION}/libOrthancPython.so
 
 mv ./libOrthancPython.so  /usr/local/share/orthanc/plugins/

--- a/orthanc/Dockerfile
+++ b/orthanc/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM python:3.13-slim-trixie
 
 MAINTAINER Sebastien Jodogne <s.jodogne@gmail.com>
 LABEL Description="Orthanc, free DICOM server" Vendor="The Orthanc project"


### PR DESCRIPTION
Upgrade base image to python:3.13-slim-trixie and download associated libOrthancPython.so.

This allows to fix 2 CVE:
https://access.redhat.com/security/cve/cve-2025-7458
https://access.redhat.com/security/cve/cve-2023-45853